### PR TITLE
fixing unit nmos simulation

### DIFF
--- a/designs/libs/tb_analog/unit_transistors/nmos_widths_tb.sch
+++ b/designs/libs/tb_analog/unit_transistors/nmos_widths_tb.sch
@@ -57,7 +57,7 @@ end
 .endc
 "}
 C {symbols/nfet_03v3_dss.sym} 190 -460 0 0 {name=M1
-L=0.6u
+L=1u
 W=\\\{wx\\\}
 nf=1
 mult=1


### PR DESCRIPTION
Width was incorrect in the NMOS unit transistor simulation, but the symbol model is still correct. This should have no effect devices already using the symbol.